### PR TITLE
Fix to save optical photons properly, when needed.

### DIFF
--- a/source/persistency/PetaloPersistencyManager.cc
+++ b/source/persistency/PetaloPersistencyManager.cc
@@ -177,7 +177,7 @@ void PetaloPersistencyManager::StoreTrajectories(G4TrajectoryContainer* tc)
       std::string key, value;
       std::getline(init_read, key, ' ');
       std::getline(init_read, value);
-      if ((key == "/Actions/RegisterTrackingAction") && (value == "OPTICAL")) {
+      if ((key == "/nexus/RegisterTrackingAction") && (value == "PetOpticalTrackingAction")) {
         save_opt_phot = true;
         break;
       }


### PR DESCRIPTION
This PR is just a fix to save optical photons in the output file, when the specific tracking action is chosen.
The code hadn't been changed following the extraction of nexus-core, therefore it was not working properly.