### PR TITLE
Simulation of positron emission and annihilation in the decay of a calibration source

### DIFF
--- a/macros/PetBox.config.mac
+++ b/macros/PetBox.config.mac
@@ -7,18 +7,20 @@
 /Geometry/PetBox/tile_vis true
 /Geometry/PetBox/tile_refl 0.
 /Geometry/PetBox/sipm_time_binning 5. picosecond
-/Geometry/PetBox/sipm_pde 0.5
+/Geometry/PetBox/sipm_pde 0.3
 
 ### GENERATOR
-/Generator/Back2back/region CENTER
+/Generator/IonGenerator/region SOURCE
+/Generator/IonGenerator/atomic_number 11
+/Generator/IonGenerator/mass_number 22
 #/Generator/SingleParticle/particle geantino
 #/Generator/SingleParticle/min_energy 1  eV
 #/Generator/SingleParticle/max_energy 1 keV
 #/Generator/SingleParticle/region CENTER
 
 ### PHYSICS
-/process/optical/processActivation Scintillation true
-/process/optical/processActivation Cerenkov      true
+#/process/optical/processActivation Scintillation true
+#/process/optical/processActivation Cerenkov      true
 
 ### VERBOSITIES
 /run/verbose 0

--- a/macros/PetBox.init.mac
+++ b/macros/PetBox.init.mac
@@ -10,7 +10,7 @@
 /nexus/RegisterGeometry PetBox
 
 ### GENERATOR
-/nexus/RegisterGenerator Back2backGammas
+/nexus/RegisterGenerator IonGenerator
 #/nexus/RegisterGenerator SingleParticleGenerator
 
 ### ACTIONS

--- a/source/geometries/Na22Source.cc
+++ b/source/geometries/Na22Source.cc
@@ -1,7 +1,7 @@
 // ----------------------------------------------------------------------------
 // petalosim | Na22Source.cc
 //
-// Na-22 calibration specific source with plastic support used at LSC.
+// Na-22 calibration specific source with plastic support used in PETit.
 //
 // The PETALO Collaboration
 // ----------------------------------------------------------------------------
@@ -12,6 +12,7 @@
 #include "nexus/MaterialsList.h"
 
 #include <G4Tubs.hh>
+#include <G4Orb.hh>
 #include <G4NistManager.hh>
 #include <G4Material.hh>
 #include <G4LogicalVolume.hh>
@@ -25,10 +26,9 @@ namespace nexus {
   Na22Source::Na22Source():
     DiskSource()
   {
-    source_diam_ = 3.*mm;
-    source_thick_ = .1*mm;
-    support_diam_ = 25.33*mm;
-    support_thick_ = 6.2*mm;
+    source_diam_   = 0.25*mm;
+    support_diam_  = 25.4*mm;
+    support_thick_ = 6.35*mm;
   }
 
   Na22Source::~Na22Source()
@@ -39,9 +39,7 @@ namespace nexus {
   void Na22Source::Construct()
   {
 
-    ///Plastic support
-    // G4double support_thick = 6.2*mm;
-    // G4double support_diam = 25.33*mm;
+    // Plastic support
     G4Tubs* support_solid =
       new G4Tubs("SUPPORT", 0., support_diam_/2., support_thick_/2., 0., twopi);
 
@@ -51,17 +49,15 @@ namespace nexus {
 
     this->SetLogicalVolume(support_logic);
 
-    // G4double source_thick = .1*mm;
-    // G4double source_diam = 3.*mm;
-    G4Tubs* source_solid =
-      new G4Tubs("SOURCE", 0., source_diam_/2., source_thick_/2., 0., twopi);
+    G4Orb* source_solid =
+      new G4Orb("NA22_SOURCE", source_diam_/2.);
     G4Material* sodium22_mat =
       G4NistManager::Instance()->FindOrBuildMaterial("G4_Na");
     G4LogicalVolume* source_logic =
-      new G4LogicalVolume(source_solid, sodium22_mat, "NA22");
+      new G4LogicalVolume(source_solid, sodium22_mat, "NA22_SOURCE");
 
-    new G4PVPlacement(0, G4ThreeVector(0., 0.,  support_thick_/2. - source_thick_/2.),
-		      source_logic, "NA22",
+    new G4PVPlacement(0, G4ThreeVector(0., 0., 0.),
+		      source_logic, "NA22_SOURCE",
 		      support_logic, false, 0, false);
     G4VisAttributes source_col = nexus::LightGreen();
     source_col.SetForceSolid(true);

--- a/source/geometries/Na22Source.h
+++ b/source/geometries/Na22Source.h
@@ -1,7 +1,7 @@
 // ----------------------------------------------------------------------------
 // petalosim | Na22Source.h
 //
-// Na-22 calibration specific source with plastic support used at LSC.
+// Na-22 calibration specific source with plastic support used in PETit.
 //
 // The PETALO Collaboration
 // ----------------------------------------------------------------------------
@@ -22,23 +22,6 @@ namespace nexus {
     ~Na22Source();
 
     void Construct();
-
-    /* G4double GetSourceDiameter();  */
-    /* G4double GetSourceThickness(); */
-
-    /* G4double GetSupportDiameter(); */
-    /* G4double GetSupportThickness(); */
-
-  private:
-
-    /* // Dimension of the source itself */
-    /* G4double source_diam_; */
-    /* G4double source_thick_; */
-
-    /* // Dimension of the whole support */
-    /* G4double support_diam_; */
-    /* G4double support_thick_; */
-
 
   };
 }

--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -221,13 +221,14 @@ void PetBox::BuildBox()
   Na22Source na22 = Na22Source();
   na22.Construct();
   G4LogicalVolume* na22_logic = na22.GetLogicalVolume();
-  G4double na22_pos = - air_source_tube_len/2 + na22.GetSupportDiameter()/2 + 10.* mm;
+  G4double source_offset_y = -0.9 * mm;
+  G4double na22_pos = - box_size_/2 + box_thickness_ + air_source_tube_len / 2. - source_offset_y;
 
   new G4PVPlacement(G4Transform3D(rot, G4ThreeVector(0., 0., na22_pos)), na22_logic,
                     "NA22_SOURCE_SUPPORT", air_source_tube_logic, false, 0, false);
 
   source_gen_ = new SpherePointSampler(0, na22.GetSourceDiameter()/2,
-                                       G4ThreeVector(0, -0.9*mm, 0.));
+                                       G4ThreeVector(0, source_offset_y, 0.));
 
   // SOURCE TUBE INSIDE BOX
   G4Tubs *source_tube_inside_box_solid =

--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -12,12 +12,14 @@
 #include "TileFBK.h"
 #include "PetMaterialsList.h"
 #include "PetOpticalMaterialProperties.h"
+#include "Na22Source.h"
 
 #include "nexus/Visibilities.h"
 #include "nexus/IonizationSD.h"
 #include "nexus/FactoryBase.h"
 #include "nexus/MaterialsList.h"
 #include "nexus/OpticalMaterialProperties.h"
+#include "nexus/SpherePointSampler.h"
 
 #include <G4GenericMessenger.hh>
 #include <G4LogicalVolume.hh>
@@ -213,6 +215,19 @@ void PetBox::BuildBox()
 
   new G4PVPlacement(0, G4ThreeVector(0., 0., source_tube_thick_roof_ / 2.), air_source_tube_logic,
                     "AIR_SOURCE_TUBE", source_tube_logic, false, 0, false);
+
+  // ENCAPSULATED SOURCE
+
+  Na22Source na22 = Na22Source();
+  na22.Construct();
+  G4LogicalVolume* na22_logic = na22.GetLogicalVolume();
+  G4double na22_pos = - air_source_tube_len/2 + na22.GetSupportDiameter()/2 + 10.* mm;
+
+  new G4PVPlacement(G4Transform3D(rot, G4ThreeVector(0., 0., na22_pos)), na22_logic,
+                    "NA22_SOURCE_SUPPORT", air_source_tube_logic, false, 0, false);
+
+  source_gen_ = new SpherePointSampler(0, na22.GetSourceDiameter()/2,
+                                       G4ThreeVector(0, -0.9*mm, 0.));
 
   // SOURCE TUBE INSIDE BOX
   G4Tubs *source_tube_inside_box_solid =
@@ -503,10 +518,10 @@ void PetBox::BuildBox()
     //source_tube_col.SetForceSolid(true);
     source_tube_logic->SetVisAttributes(source_tube_col);
     G4VisAttributes air_source_tube_col = nexus::DarkGrey();
-    air_source_tube_col.SetForceSolid(true);
+    // air_source_tube_col.SetForceSolid(true);
     air_source_tube_logic->SetVisAttributes(air_source_tube_col);
     G4VisAttributes air_source_tube_inside_box_col = nexus::White();
-    air_source_tube_inside_box_col.SetForceSolid(true);
+    //air_source_tube_inside_box_col.SetForceSolid(true);
     source_tube_inside_box_logic->SetVisAttributes(air_source_tube_inside_box_col);
     G4VisAttributes active_col = nexus::Blue();
     active_logic->SetVisAttributes(active_col);
@@ -614,17 +629,21 @@ G4ThreeVector PetBox::GenerateVertex(const G4String &region) const
   G4ThreeVector vertex(0., 0., 0.);
 
   if (region == "CENTER")
-  {
-    return vertex;
-  }
+    {
+      return vertex;
+    }
   else if (region == "AD_HOC")
-  {
-    vertex = source_pos_;
-  }
+    {
+      vertex = source_pos_;
+    }
+  else if (region == "SOURCE")
+    {
+      vertex = source_gen_->GenerateVertex("VOLUME");
+    }
   else
-  {
-    G4Exception("[PetBox]", "GenerateVertex()", FatalException,
-                "Unknown vertex generation region!");
-  }
+    {
+      G4Exception("[PetBox]", "GenerateVertex()", FatalException,
+                  "Unknown vertex generation region!");
+    }
   return vertex;
 }

--- a/source/geometries/PetBox.h
+++ b/source/geometries/PetBox.h
@@ -20,6 +20,11 @@ class TileHamamatsuVUV;
 class TileHamamatsuBlue;
 class TileFBK;
 
+namespace nexus
+{
+class SpherePointSampler;
+}
+
 using namespace nexus;
 
 class PetBox : public GeometryBase
@@ -87,7 +92,9 @@ private:
   G4double max_step_size_;
 
   /// Messenger for the definition of control commands
-  G4GenericMessenger *msg_;
+  G4GenericMessenger* msg_;
+
+  SpherePointSampler* source_gen_;
 };
 
 #endif

--- a/source/physics/PositronAnnihilation.cc
+++ b/source/physics/PositronAnnihilation.cc
@@ -24,17 +24,12 @@
 PositronAnnihilation::PositronAnnihilation(const G4String& name)
   :  G4VEmProcess(name)
   {
-    //   theGamma = G4Gamma::Gamma();
-    //    theElectron = G4Electron::Electron();
     SetCrossSectionType(fEmDecreasing);
     SetBuildTableFlag(false);
     SetStartFromNullFlag(false);
-    //SetSecondaryParticle(theGamma);
     SetProcessSubType(fAnnihilation);
     enableAtRestDoIt = true;
     mainSecondaries = 2;
-    //  fEntanglementModelID = G4PhysicsModelCatalog::GetModelID("model_GammaGammaEntanglement");
-    //  G4cout << "Constructor" << G4endl;
   }
 
 
@@ -78,7 +73,7 @@ G4VParticleChange* PositronAnnihilation::AtRestDoIt(const G4Track& aTrack,
 
    fParticleChange.SetNumberOfSecondaries(2) ;
 
-   G4double r  = CLHEP::RandGauss::shoot(0.,0.0011); // hard coded value: it gives
+   G4double r  = CLHEP::RandGauss::shoot(0.,0.00092); // It gives
    // a distribution of deviation of collinearity with 0.5 degrees FWHM.
 
    G4double E1 = electron_mass_c2 + r;

--- a/source/physics/PositronAnnihilation.cc
+++ b/source/physics/PositronAnnihilation.cc
@@ -70,7 +70,7 @@ G4VParticleChange* PositronAnnihilation::AtRestDoIt(const G4Track& aTrack,
 // Caveat: the positron annihilates always at rest, therefore, the 4-momentum
 // is not conserved.
 //
-// Note : Effects due to binding of atomic electrons are negliged.
+// Note : Effects due to binding of atomic electrons are neglected.
 
 {
    fParticleChange.InitializeForPostStep(aTrack);

--- a/source/physics/PositronAnnihilation.cc
+++ b/source/physics/PositronAnnihilation.cc
@@ -73,8 +73,13 @@ G4VParticleChange* PositronAnnihilation::AtRestDoIt(const G4Track& aTrack,
 
    fParticleChange.SetNumberOfSecondaries(2) ;
 
-   G4double r  = CLHEP::RandGauss::shoot(0.,0.00092); // It gives
-   // a distribution of deviation of collinearity with 0.5 degrees FWHM.
+   G4double r  = CLHEP::RandGauss::shoot(0.,0.00099); // It gives
+   // a distribution of deviation of collinearity with 0.54 degrees FWHM.
+   // Value taken from "Limit of Spatial Resolution in FDG-PET due to
+   // Annihilation Photon Non-Collinearity", Shibuya, K. et al.
+   // DOI: 10.1007/978-3-540-36841-0_411
+   // World Congress on Medical Physics and Biomedical Engineering 2006, IFMBE
+
 
    G4double E1 = electron_mass_c2 + r;
    G4double E2 = electron_mass_c2 - r;

--- a/source/physics/PositronAnnihilation.cc
+++ b/source/physics/PositronAnnihilation.cc
@@ -1,0 +1,113 @@
+// ----------------------------------------------------------------------------
+// petalosim | PositronAnnihilation.cc
+//
+// This class implements the process of pair production with
+// non collinearity for gammas.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#include "PositronAnnihilation.h"
+
+#include <G4UnitsTable.hh>
+#include <globals.hh>
+#include <G4PhysicalConstants.hh>
+#include <Randomize.hh>
+#include <G4Gamma.hh>
+#include <G4Electron.hh>
+#include <G4Positron.hh>
+#include <G4eeToTwoGammaModel.hh>
+
+#include <G4PhysicalConstants.hh>
+#include <G4SystemOfUnits.hh>
+
+PositronAnnihilation::PositronAnnihilation(const G4String& name)
+  :  G4VEmProcess(name)
+  {
+    //   theGamma = G4Gamma::Gamma();
+    //    theElectron = G4Electron::Electron();
+    SetCrossSectionType(fEmDecreasing);
+    SetBuildTableFlag(false);
+    SetStartFromNullFlag(false);
+    //SetSecondaryParticle(theGamma);
+    SetProcessSubType(fAnnihilation);
+    enableAtRestDoIt = true;
+    mainSecondaries = 2;
+    //  fEntanglementModelID = G4PhysicsModelCatalog::GetModelID("model_GammaGammaEntanglement");
+    //  G4cout << "Constructor" << G4endl;
+  }
+
+
+PositronAnnihilation::~PositronAnnihilation() {}
+
+G4bool PositronAnnihilation::IsApplicable(const G4ParticleDefinition& p)
+{
+  return (&p == G4Positron::Positron());
+}
+
+G4double PositronAnnihilation::AtRestGetPhysicalInteractionLength(const G4Track&, G4ForceCondition* condition)
+{
+  *condition = NotForced;
+  return 0.0;
+}
+
+void PositronAnnihilation::InitialiseProcess(const G4ParticleDefinition*)
+ {
+   if(!isInitialised) {
+     isInitialised = true;
+     if(nullptr == EmModel(0)) { SetEmModel(new G4eeToTwoGammaModel()); }
+     EmModel(0)->SetLowEnergyLimit(MinKinEnergy());
+     EmModel(0)->SetHighEnergyLimit(MaxKinEnergy());
+     AddEmModel(1, EmModel(0));
+   }
+ }
+
+G4VParticleChange* PositronAnnihilation::AtRestDoIt(const G4Track& aTrack,
+                                                    const G4Step&  )
+//
+// Performs the e+ e- annihilation when both particles are assumed at rest.
+// It generates two photons almost back-to-back, according to a given
+// spread in the angle between the photons. The energy of the photons also
+// deviates from the electron_mass, due to Doppler shift.
+// The angular distribution is isotropic.
+//
+// Note : Effects due to binding of atomic electrons are negliged.
+
+{
+   fParticleChange.InitializeForPostStep(aTrack);
+
+   fParticleChange.SetNumberOfSecondaries(2) ;
+
+   G4double r  = CLHEP::RandGauss::shoot(0.,0.0011); // hard coded value: it gives
+   // a distribution of deviation of collinearity with 0.5 degrees FWHM.
+
+   G4double E1 = electron_mass_c2 + r;
+   G4double E2 = electron_mass_c2 - r;
+
+   G4double DeltaTeta = 2*r/electron_mass_c2;
+
+   G4double cosTeta = G4RandFlat::shoot(-1.0, 1.0);
+   G4double sinTeta = sqrt(1.-cosTeta*cosTeta);
+   G4double Phi     = twopi * G4UniformRand() ;
+   G4double Phi1     = (twopi * G4UniformRand())/2. ;
+   G4ThreeVector Direction (sinTeta*cos(Phi), sinTeta*sin(Phi), cosTeta);
+
+
+   G4ThreeVector DirectionPhoton (sin(DeltaTeta)*cos(Phi1),sin(DeltaTeta)*sin(Phi1),cos(DeltaTeta));
+   DirectionPhoton.rotateUz(Direction);
+
+
+   fParticleChange.AddSecondary( new G4DynamicParticle (G4Gamma::Gamma(),
+                                                        DirectionPhoton, E1) );
+   fParticleChange.AddSecondary( new G4DynamicParticle (G4Gamma::Gamma(),
+                                                        -Direction, E2) );
+
+   fParticleChange.ProposeLocalEnergyDeposit(0.);
+
+   // Kill the incident positron
+   //
+   fParticleChange.ProposeTrackStatus( fStopAndKill );
+
+   return &fParticleChange;
+
+}

--- a/source/physics/PositronAnnihilation.h
+++ b/source/physics/PositronAnnihilation.h
@@ -1,0 +1,46 @@
+// ----------------------------------------------------------------------------
+// petalosim | PositronAnnihilation.h
+//
+// This class implements the process of pair production with
+// non collinearity for gammas.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef POS_ANNIHIL_H
+#define POS_ANNIHIL_H
+
+#include <G4VEmProcess.hh>
+
+class G4ParticleDefinition;
+
+class PositronAnnihilation : public G4VEmProcess
+
+{
+ public:
+
+  PositronAnnihilation(const G4String& name = "pos_annihil");
+  ~PositronAnnihilation() override;
+
+  G4bool IsApplicable(const G4ParticleDefinition& p) final;
+
+  G4VParticleChange* AtRestDoIt(const G4Track& aTrack,
+                                const G4Step& aStep) override;
+
+  G4double AtRestGetPhysicalInteractionLength(const G4Track& track,
+                                              G4ForceCondition* condition
+                                               ) override;
+
+  PositronAnnihilation & operator=(const PositronAnnihilation &right) = delete;
+  PositronAnnihilation(const PositronAnnihilation&) = delete;
+
+  protected:
+
+  void InitialiseProcess(const G4ParticleDefinition*) override;
+
+  private:
+
+  G4bool isInitialised = false;
+};
+
+#endif

--- a/source/physics_lists/PetaloPhysics.h
+++ b/source/physics_lists/PetaloPhysics.h
@@ -13,6 +13,7 @@
 
 class G4GenericMessenger;
 class WavelengthShifting;
+class PositronAnnihilation;
 
 class PetaloPhysics : public G4VPhysicsConstructor
 {
@@ -34,6 +35,7 @@ private:
 
   G4GenericMessenger *msg_;
   WavelengthShifting *wls_;
+  PositronAnnihilation* pos_annihil_;
 };
 
 #endif


### PR DESCRIPTION
The aim of this PR is to simulate correctly the positron emission and annihilation in the decay of a calibration source. The approximation we have been used so far, was to simulate only two back-to-back gammas of 511 keV. 
In this PR we:

1. Add a new physical process for the positron annihilation, which simulates correctly the non-collinearity of the gammas and the Doppler shift of their energies. CAVEATs: the annihilation always occurs when the positron is at rest, therefore its range may not be completely correct. Also, the energy is not conserved in the process. The angle distribution depends on the electronic density of the material: we have hard-coded implemented the distribution commonly used in medical physics, which corresponds to typical body tissues. We believe that the case of a sodium source should not be that different, since the density of water (similar to body) and sodium is practically the same (1 g/cm3 vs 0.968 g/cm3).
2. Simulate the Na22 source that we use in PETit, together with a dedicate generator.