### PR TITLE
Add min charge threshold to `PetSensorsEventAction`

### DIFF
--- a/macros/PET_full_body.config.mac
+++ b/macros/PET_full_body.config.mac
@@ -20,7 +20,7 @@
 /Generator/Back2back/region AD_HOC
 #/Generator/Back2back/region CUSTOM
 
-/Actions/PetaloEventAction/energy_threshold .511 MeV
+/Actions/PetaloEventAction/min_energy .511 MeV
 
 ### VERBOSITIES
 /run/verbose 1

--- a/macros/PET_full_body_sens.config.mac
+++ b/macros/PET_full_body_sens.config.mac
@@ -23,7 +23,7 @@
 ### GENERATOR
 /Generator/SensMap/num_gammas 1
 
-/Actions/PetaloEventAction/energy_threshold 0.95 MeV
+/Actions/PetaloEventAction/min_energy 0.95 MeV
 
 ### VERBOSITIES
 /run/verbose 1

--- a/macros/PET_steps.config.mac
+++ b/macros/PET_steps.config.mac
@@ -18,7 +18,7 @@
 /Generator/Back2back/region CENTER
 #/Generator/Back2back/region CUSTOM
 
-#/Actions/PetaloEventAction/energy_threshold .511 MeV
+#/Actions/PetaloEventAction/min_energy .511 MeV
 
 /Actions/PetSaveAllSteppingAction/select_particle opticalphoton
 

--- a/macros/PetBox.config.mac
+++ b/macros/PetBox.config.mac
@@ -19,6 +19,8 @@
 #/Generator/SingleParticle/max_energy 1 keV
 #/Generator/SingleParticle/region CENTER
 
+/Actions/PetSensorsEventAction/min_charge 50
+
 ### PHYSICS
 #/process/optical/processActivation Scintillation true
 #/process/optical/processActivation Cerenkov      true

--- a/source/actions/PetAnalysisEventAction.cc
+++ b/source/actions/PetAnalysisEventAction.cc
@@ -33,22 +33,22 @@ REGISTER_CLASS(PetAnalysisEventAction, G4UserEventAction)
 
 PetAnalysisEventAction::PetAnalysisEventAction() : G4UserEventAction(),
                                                    nevt_(0), nupdate_(10),
-                                                   energy_threshold_(0.),
-                                                   energy_max_(DBL_MAX),
+                                                   min_energy_(0.),
+                                                   max_energy_(DBL_MAX),
                                                    file_name_("OpticalEvent"),
                                                    file_no_(0)
 {
   msg_ = new G4GenericMessenger(this, "/Actions/PetAnalysisEventAction/");
 
   G4GenericMessenger::Command &thresh_cmd =
-      msg_->DeclareProperty("energy_threshold", energy_threshold_,
+      msg_->DeclareProperty("min_energy", min_energy_,
                             "Minimum deposited energy to save the event to file.");
-  thresh_cmd.SetParameterName("energy_threshold", true);
+  thresh_cmd.SetParameterName("min_energy", true);
   thresh_cmd.SetUnitCategory("Energy");
-  thresh_cmd.SetRange("energy_threshold>0.");
+  thresh_cmd.SetRange("min_energy>0.");
 
   G4GenericMessenger::Command &max_energy_cmd =
-      msg_->DeclareProperty("max_energy", energy_max_,
+      msg_->DeclareProperty("max_energy", max_energy_,
                             "Maximum deposited energy to save the event to file.");
   max_energy_cmd.SetParameterName("max_energy", true);
   max_energy_cmd.SetUnitCategory("Energy");
@@ -88,7 +88,7 @@ void PetAnalysisEventAction::EndOfEventAction(const G4Event *event)
 
   // Determine whether total energy deposit in ionization sensitive
   // detectors is above threshold
-  if (energy_threshold_ >= 0.)
+  if (min_energy_ >= 0.)
   {
 
     // Get the trajectories stored for this event and loop through them
@@ -125,7 +125,7 @@ void PetAnalysisEventAction::EndOfEventAction(const G4Event *event)
     {
       pm->InteractingEvent(false);
     }
-    if (!event->IsAborted() && edep > energy_threshold_ && edep < energy_max_)
+    if (!event->IsAborted() && edep > min_energy_ && edep < max_energy_)
     {
       pm->StoreCurrentEvent(true);
       hNPhotons->Fill(n_opt_photons);

--- a/source/actions/PetAnalysisEventAction.h
+++ b/source/actions/PetAnalysisEventAction.h
@@ -34,8 +34,8 @@ public:
 private:
   G4GenericMessenger *msg_;
   G4int nevt_, nupdate_;
-  G4double energy_threshold_;
-  G4double energy_max_;
+  G4double min_energy_;
+  G4double max_energy_;
   G4String file_name_;
   G4int file_no_;
 

--- a/source/actions/PetSensorsEventAction.cc
+++ b/source/actions/PetSensorsEventAction.cc
@@ -30,21 +30,21 @@ REGISTER_CLASS(PetSensorsEventAction, G4UserEventAction)
 PetSensorsEventAction::PetSensorsEventAction() : G4UserEventAction(),
                                                  nevt_(0),
                                                  nupdate_(10),
-                                                 energy_threshold_(0.),
-                                                 energy_max_(DBL_MAX),
+                                                 min_energy_(0.),
+                                                 max_energy_(DBL_MAX),
                                                  min_charge_(0)
 {
   msg_ = new G4GenericMessenger(this, "/Actions/PetSensorsEventAction/");
 
   G4GenericMessenger::Command &thresh_cmd =
-      msg_->DeclareProperty("energy_threshold", energy_threshold_,
+      msg_->DeclareProperty("min_energy", min_energy_,
                             "Minimum deposited energy to save the event to file.");
-  thresh_cmd.SetParameterName("energy_threshold", true);
+  thresh_cmd.SetParameterName("min_energy", true);
   thresh_cmd.SetUnitCategory("Energy");
-  thresh_cmd.SetRange("energy_threshold>0.");
+  thresh_cmd.SetRange("min_energy>0.");
 
   G4GenericMessenger::Command &max_energy_cmd =
-      msg_->DeclareProperty("max_energy", energy_max_,
+      msg_->DeclareProperty("max_energy", max_energy_,
                             "Maximum deposited energy to save the event to file.");
   max_energy_cmd.SetParameterName("max_energy", true);
   max_energy_cmd.SetUnitCategory("Energy");
@@ -75,7 +75,7 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
 
   // Determine whether total energy deposit in ionization sensitive
   // detectors is above threshold
-  if (energy_threshold_ >= 0.)
+  if (min_energy_ >= 0.)
   {
 
     // Get the trajectories stored for this event and loop through them
@@ -132,7 +132,7 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
 
     PetaloPersistencyManager *pm = dynamic_cast<PetaloPersistencyManager *>(G4VPersistencyManager::GetPersistencyManager());
 
-    // if (edep > _energy_threshold) pm->StoreCurrentEvent(true);
+    // if (edep > _min_energy) pm->StoreCurrentEvent(true);
     // else pm->StoreCurrentEvent(false);
     if (!event->IsAborted() && edep > 0)
     {
@@ -142,7 +142,7 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
     {
       pm->InteractingEvent(false);
     }
-    if (!event->IsAborted() && charge_above_th && edep > energy_threshold_ && edep < energy_max_)
+    if (!event->IsAborted() && charge_above_th && edep > min_energy_ && edep < max_energy_)
     {
       pm->StoreCurrentEvent(true);
     }

--- a/source/actions/PetSensorsEventAction.cc
+++ b/source/actions/PetSensorsEventAction.cc
@@ -108,27 +108,28 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
     G4String sdname = hct->GetSDname(1);
     int hcid = sdmgr->GetCollectionID(sdname+"/"+hcname);
 
-    G4VHitsCollection* SensHits = hce->GetHC(hcid);
-    SensorHitsCollection* hits = dynamic_cast<SensorHitsCollection*>(SensHits);
-    if (!hits) return;
-    for (size_t i=0; i<hits->entries(); i++) {
-      SensorHit* hit = dynamic_cast<SensorHit*>(hits->GetHit(i));
-      if (!hit) continue;
+    if (hcname == SensorSD::GetCollectionUniqueName()){
+      G4VHitsCollection* SensHits = hce->GetHC(hcid);
+      SensorHitsCollection* hits = dynamic_cast<SensorHitsCollection*>(SensHits);
+      if (!hits) return;
+      for (size_t i=0; i<hits->entries(); i++) {
+        SensorHit* hit = dynamic_cast<SensorHit*>(hits->GetHit(i));
+        if (!hit) continue;
 
-      // Reject TOF hits
-      if (hit->GetPmtID() >= 0) {
-        const std::map<G4double, G4int>& wvfm = hit->GetHistogram();
-        std::map<G4double, G4int>::const_iterator it;
+        // Reject TOF hits
+        if (hit->GetPmtID() >= 0) {
+          const std::map<G4double, G4int>& wvfm = hit->GetHistogram();
+          std::map<G4double, G4int>::const_iterator it;
 
-        for (it = wvfm.begin(); it != wvfm.end(); ++it) {
-          amplitude = amplitude + (*it).second;
-        }
-      } else continue;
-    }
-    if (amplitude>min_charge_){
-      charge_above_th = true;
-    }
-
+          for (it = wvfm.begin(); it != wvfm.end(); ++it) {
+            amplitude = amplitude + (*it).second;
+          }
+        } else continue;
+      }
+      if (amplitude>min_charge_){
+        charge_above_th = true;
+      }
+  }
 
     PetaloPersistencyManager *pm = dynamic_cast<PetaloPersistencyManager *>(G4VPersistencyManager::GetPersistencyManager());
 

--- a/source/actions/PetSensorsEventAction.cc
+++ b/source/actions/PetSensorsEventAction.cc
@@ -96,8 +96,7 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
       }
     }
 
-    G4bool any_charge_in_sns = false;
-    G4bool charge_above_th   = false;
+    G4bool charge_above_th = false;
     G4double amplitude = 0.;
 
     G4SDManager* sdmgr = G4SDManager::GetSDMpointer();
@@ -118,11 +117,6 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
       if (hcname == SensorSD::GetCollectionUniqueName()){
         G4VHitsCollection* SensHits = hc->GetHC(hcid);
         SensorHitsCollection* hits = dynamic_cast<SensorHitsCollection*>(SensHits);
-        size_t sns_hit_size = hits->GetSize();
-
-        if (sns_hit_size>0){
-          any_charge_in_sns = true;
-        }
 
         for (size_t j=0; j<hits->entries(); j++) {
           SensorHit* hit = dynamic_cast<SensorHit*>(hits->GetHit(j));
@@ -154,7 +148,7 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
     {
       pm->InteractingEvent(false);
     }
-    if (!event->IsAborted() && any_charge_in_sns && charge_above_th && edep > energy_threshold_ && edep < energy_max_)
+    if (!event->IsAborted() && charge_above_th && edep > energy_threshold_ && edep < energy_max_)
     {
       pm->StoreCurrentEvent(true);
     }

--- a/source/actions/PetSensorsEventAction.cc
+++ b/source/actions/PetSensorsEventAction.cc
@@ -133,8 +133,6 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
 
     PetaloPersistencyManager *pm = dynamic_cast<PetaloPersistencyManager *>(G4VPersistencyManager::GetPersistencyManager());
 
-    // if (edep > _min_energy) pm->StoreCurrentEvent(true);
-    // else pm->StoreCurrentEvent(false);
     if (!event->IsAborted() && edep > 0)
     {
       pm->InteractingEvent(true);

--- a/source/actions/PetSensorsEventAction.cc
+++ b/source/actions/PetSensorsEventAction.cc
@@ -97,6 +97,9 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
     }
 
     G4bool any_charge_in_sns = false;
+    G4bool charge_above_th   = false;
+    G4double amplitude = 0.;
+
     G4SDManager* sdmgr = G4SDManager::GetSDMpointer();
     G4HCtable* hct = sdmgr->GetHCtable();
 
@@ -116,11 +119,26 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
         G4VHitsCollection* SensHits = hc->GetHC(hcid);
         SensorHitsCollection* hits = dynamic_cast<SensorHitsCollection*>(SensHits);
         size_t sns_hit_size = hits->GetSize();
-        if (sns_hit_size>0)
-        {
+
+        if (sns_hit_size>0){
           any_charge_in_sns = true;
         }
+
+        for (size_t j=0; j<hits->entries(); j++) {
+          SensorHit* hit = dynamic_cast<SensorHit*>(hits->GetHit(j));
+
+          const std::map<G4double, G4int>& wvfm = hit->GetHistogram();
+          std::map<G4double, G4int>::const_iterator it;
+
+          for (it = wvfm.begin(); it != wvfm.end(); ++it) {
+            amplitude = amplitude + (*it).second;
+          }
+        }
       }
+    }
+
+    if (amplitude>min_charge_){
+      charge_above_th = true;
     }
 
 

--- a/source/actions/PetSensorsEventAction.cc
+++ b/source/actions/PetSensorsEventAction.cc
@@ -27,8 +27,12 @@ using namespace nexus;
 
 REGISTER_CLASS(PetSensorsEventAction, G4UserEventAction)
 
-PetSensorsEventAction::PetSensorsEventAction() : G4UserEventAction(), nevt_(0), nupdate_(10), energy_threshold_(0.),
-                                         energy_max_(DBL_MAX)
+PetSensorsEventAction::PetSensorsEventAction() : G4UserEventAction(),
+                                                 nevt_(0),
+                                                 nupdate_(10),
+                                                 energy_threshold_(0.),
+                                                 energy_max_(DBL_MAX),
+                                                 min_charge_(0)
 {
   msg_ = new G4GenericMessenger(this, "/Actions/PetSensorsEventAction/");
 
@@ -45,6 +49,9 @@ PetSensorsEventAction::PetSensorsEventAction() : G4UserEventAction(), nevt_(0), 
   max_energy_cmd.SetParameterName("max_energy", true);
   max_energy_cmd.SetUnitCategory("Energy");
   max_energy_cmd.SetRange("max_energy>0.");
+
+  msg_->DeclareProperty("min_charge", min_charge_,
+    "Minimum charge detected to save the event to file.");
 }
 
 PetSensorsEventAction::~PetSensorsEventAction()
@@ -129,7 +136,7 @@ void PetSensorsEventAction::EndOfEventAction(const G4Event *event)
     {
       pm->InteractingEvent(false);
     }
-    if (!event->IsAborted() && any_charge_in_sns && edep > energy_threshold_ && edep < energy_max_)
+    if (!event->IsAborted() && any_charge_in_sns && charge_above_th && edep > energy_threshold_ && edep < energy_max_)
     {
       pm->StoreCurrentEvent(true);
     }

--- a/source/actions/PetSensorsEventAction.h
+++ b/source/actions/PetSensorsEventAction.h
@@ -36,6 +36,7 @@ private:
   G4int nevt_, nupdate_;
   G4double energy_threshold_;
   G4double energy_max_;
+  G4int min_charge_;
 };
 
 #endif

--- a/source/actions/PetSensorsEventAction.h
+++ b/source/actions/PetSensorsEventAction.h
@@ -34,8 +34,8 @@ public:
 private:
   G4GenericMessenger *msg_;
   G4int nevt_, nupdate_;
-  G4double energy_threshold_;
-  G4double energy_max_;
+  G4double min_energy_;
+  G4double max_energy_;
   G4int min_charge_;
 };
 

--- a/source/actions/PetaloEventAction.cc
+++ b/source/actions/PetaloEventAction.cc
@@ -26,20 +26,20 @@ using namespace nexus;
 
 REGISTER_CLASS(PetaloEventAction, G4UserEventAction)
 
-PetaloEventAction::PetaloEventAction() : G4UserEventAction(), nevt_(0), nupdate_(10), energy_threshold_(0.),
-                                         energy_max_(DBL_MAX)
+PetaloEventAction::PetaloEventAction() : G4UserEventAction(), nevt_(0), nupdate_(10), min_energy_(0.),
+                                         max_energy_(DBL_MAX)
 {
   msg_ = new G4GenericMessenger(this, "/Actions/PetaloEventAction/");
 
   G4GenericMessenger::Command &thresh_cmd =
-      msg_->DeclareProperty("energy_threshold", energy_threshold_,
+      msg_->DeclareProperty("min_energy", min_energy_,
                             "Minimum deposited energy to save the event to file.");
-  thresh_cmd.SetParameterName("energy_threshold", true);
+  thresh_cmd.SetParameterName("min_energy", true);
   thresh_cmd.SetUnitCategory("Energy");
-  thresh_cmd.SetRange("energy_threshold>0.");
+  thresh_cmd.SetRange("min_energy>0.");
 
   G4GenericMessenger::Command &max_energy_cmd =
-      msg_->DeclareProperty("max_energy", energy_max_,
+      msg_->DeclareProperty("max_energy", max_energy_,
                             "Maximum deposited energy to save the event to file.");
   max_energy_cmd.SetParameterName("max_energy", true);
   max_energy_cmd.SetUnitCategory("Energy");
@@ -67,7 +67,7 @@ void PetaloEventAction::EndOfEventAction(const G4Event *event)
 
   // Determine whether total energy deposit in ionization sensitive
   // detectors is above threshold
-  if (energy_threshold_ >= 0.)
+  if (min_energy_ >= 0.)
   {
 
     // Get the trajectories stored for this event and loop through them
@@ -90,7 +90,7 @@ void PetaloEventAction::EndOfEventAction(const G4Event *event)
 
     PetaloPersistencyManager *pm = dynamic_cast<PetaloPersistencyManager *>(G4VPersistencyManager::GetPersistencyManager());
 
-    // if (edep > _energy_threshold) pm->StoreCurrentEvent(true);
+    // if (edep > _min_energy) pm->StoreCurrentEvent(true);
     // else pm->StoreCurrentEvent(false);
     if (!event->IsAborted() && edep > 0)
     {
@@ -100,7 +100,7 @@ void PetaloEventAction::EndOfEventAction(const G4Event *event)
     {
       pm->InteractingEvent(false);
     }
-    if (!event->IsAborted() && edep > energy_threshold_ && edep < energy_max_)
+    if (!event->IsAborted() && edep > min_energy_ && edep < max_energy_)
     {
       pm->StoreCurrentEvent(true);
     }

--- a/source/actions/PetaloEventAction.h
+++ b/source/actions/PetaloEventAction.h
@@ -34,8 +34,8 @@ public:
 private:
   G4GenericMessenger *msg_;
   G4int nevt_, nupdate_;
-  G4double energy_threshold_;
-  G4double energy_max_;
+  G4double min_energy_;
+  G4double max_energy_;
 };
 
 #endif

--- a/source/generators/DoubleParticle.cc
+++ b/source/generators/DoubleParticle.cc
@@ -34,7 +34,7 @@ REGISTER_CLASS(DoubleParticle, G4VPrimaryGenerator)
 
 DoubleParticle::DoubleParticle():
 G4VPrimaryGenerator(), msg_(0), particle_definition_(0),
-energy_min_(0.), energy_max_(0.), geom_(0)
+energy_min_(0.), max_energy_(0.), geom_(0)
 {
   msg_ = new G4GenericMessenger(this, "/Generator/DoubleParticle/",
     "Control commands of single-particle generator.");
@@ -50,7 +50,7 @@ energy_min_(0.), energy_max_(0.), geom_(0)
   min_energy.SetRange("min_energy>0.");
 
   G4GenericMessenger::Command& max_energy =
-    msg_->DeclareProperty("max_energy", energy_max_,
+    msg_->DeclareProperty("max_energy", max_energy_,
       "Set maximum kinetic energy of the particle");
   max_energy.SetUnitCategory("Energy");
 
@@ -164,8 +164,8 @@ void DoubleParticle::GeneratePrimaryVertex(G4Event* event)
 
 G4double DoubleParticle::RandomEnergy() const
 {
-  if (energy_max_ == energy_min_)
+  if (max_energy_ == energy_min_)
     return energy_min_;
   else
-    return (G4UniformRand()*(energy_max_ - energy_min_) + energy_min_);
+    return (G4UniformRand()*(max_energy_ - energy_min_) + energy_min_);
 }

--- a/source/generators/DoubleParticle.h
+++ b/source/generators/DoubleParticle.h
@@ -40,7 +40,7 @@ namespace nexus {
     void SetParticleDefinition(G4String);
 
     /// Generate a random kinetic energy with flat probability in
-    //  the interval [energy_min, energy_max].
+    //  the interval [energy_min, max_energy].
     G4double RandomEnergy() const;
 
   private:
@@ -49,7 +49,7 @@ namespace nexus {
     G4ParticleDefinition* particle_definition_;
 
     G4double energy_min_; ///< Minimum kinetic energy
-    G4double energy_max_; ///< Maximum kinetic energy
+    G4double max_energy_; ///< Maximum kinetic energy
 
     const GeometryBase* geom_; ///< Pointer to the detector geometry
 

--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -330,7 +330,7 @@ void PetBox::BuildBox()
         new G4Box("ENTRY_PANEL", entry_panel_x_size_/2., entry_panel_y_size_/2., panel_thickness_/2.);
 
     G4Material *pyrex = G4NistManager::Instance()->FindOrBuildMaterial("G4_Pyrex_Glass");
-    pyrex->SetMaterialPropertiesTable(petopticalprops::Pyrex_vidrasa());
+    //pyrex->SetMaterialPropertiesTable(petopticalprops::Pyrex_vidrasa());
 
     G4LogicalVolume *entry_panel_logic =
         new G4LogicalVolume(entry_panel_solid, pyrex, "ENTRY_PANEL");

--- a/source/geometries/PetBox.cc
+++ b/source/geometries/PetBox.cc
@@ -419,12 +419,15 @@ void PetBox::BuildBox()
 
     // Panel in front of the sensors just for the Hamamatsu Blue SiPMs
 
+    G4Material *pyrex2 = G4NistManager::Instance()->FindOrBuildMaterial("G4_Pyrex_Glass");
+    pyrex2->SetMaterialPropertiesTable(petopticalprops::Pyrex_vidrasa());
+
     G4Box *panel_sipms_solid =
       new G4Box("PANEL_SiPMs", panel_sipm_xy_size_/2., panel_sipm_xy_size_/2.,
                 (panel_thickness_ + wls_depth_)/2.);
 
     G4LogicalVolume *panel_sipms_logic =
-      new G4LogicalVolume(panel_sipms_solid, pyrex, "PANEL_SiPMs");
+      new G4LogicalVolume(panel_sipms_solid, pyrex2, "PANEL_SiPMs");
 
     // WAVELENGTH SHIFTER LAYER ON THE PANEL /////////////////////////////////
     G4Box *wls_solid =

--- a/source/geometries/TileHamamatsuVUV.cc
+++ b/source/geometries/TileHamamatsuVUV.cc
@@ -34,7 +34,7 @@ using namespace CLHEP;
 TileHamamatsuVUV::TileHamamatsuVUV() : TileGeometryBase(),
                                        tile_x_(30.9 * mm),
                                        tile_y_(30.7 * mm),
-                                       tile_z_(2.3 * mm), // From Simon's 3d model. Hamamatsu file says 2.5. To be cheched in the lab
+                                       tile_z_(2.3 * mm), // From Simón's 3d model. Hamamatsu file says 2.5. To be checked in the lab.
                                        sipm_pitch_(7.5 * mm),
                                        n_rows_(4),
                                        n_columns_(4),

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -72,7 +72,8 @@ def petalosim_params_pet_box_HamamatsuVUV(output_tmpdir):
     init_sns_id1   =  11
     init_sns_id2   = 111
     sensor_name    = 'SiPMHmtsuVUV'
-    return os.path.join(output_tmpdir, base_name+'.h5'), base_name, tile_type1, tile_type2, n_sipm, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name
+    min_charge_evt = 50
+    return os.path.join(output_tmpdir, base_name+'.h5'), base_name, tile_type1, tile_type2, n_sipm, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name, min_charge_evt
 
 @pytest.fixture(scope = 'session')
 def petalosim_params_pet_box_HamamatsuBlue(output_tmpdir):
@@ -84,7 +85,8 @@ def petalosim_params_pet_box_HamamatsuBlue(output_tmpdir):
     init_sns_id1   =  11
     init_sns_id2   = 111
     sensor_name    = 'SiPMHmtsuBlue'
-    return os.path.join(output_tmpdir, base_name+'.h5'), base_name, tile_type1, tile_type2, n_sipm, sipms_per_tile, init_sns_id1, init_sns_id2,sensor_name
+    min_charge_evt = 50
+    return os.path.join(output_tmpdir, base_name+'.h5'), base_name, tile_type1, tile_type2, n_sipm, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name, min_charge_evt
 
 @pytest.fixture(scope = 'session')
 def petalosim_params_pet_box_FBK(output_tmpdir):
@@ -96,7 +98,8 @@ def petalosim_params_pet_box_FBK(output_tmpdir):
     init_sns_id1   =  11
     init_sns_id2   = 111
     sensor_name    = 'SiPMFBKVUV'
-    return os.path.join(output_tmpdir, base_name+'.h5'), base_name, tile_type1, tile_type2, n_sipm, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name
+    min_charge_evt = 50
+    return os.path.join(output_tmpdir, base_name+'.h5'), base_name, tile_type1, tile_type2, n_sipm, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name, min_charge_evt
 
 @pytest.fixture(scope = 'session')
 def petalosim_params_pet_box_mix_Ham_FBK(output_tmpdir):
@@ -108,7 +111,8 @@ def petalosim_params_pet_box_mix_Ham_FBK(output_tmpdir):
     init_sns_id1   = 11
     init_sns_id2   = 111
     sensor_name    = 'SiPMFBKVUV', 'SiPMHmtsuVUV'
-    return os.path.join(output_tmpdir, base_name+'.h5'), base_name, tile_type1, tile_type2, n_sipm, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name
+    min_charge_evt = 50
+    return os.path.join(output_tmpdir, base_name+'.h5'), base_name, tile_type1, tile_type2, n_sipm, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name, min_charge_evt
 
 
 @pytest.fixture(scope="module",

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -159,7 +159,7 @@ def test_create_petalo_output_file_pet_box_all_tiles(config_tmpdir, output_tmpdi
 /nexus/RegisterGeometry PetBox
 
 ### GENERATOR
-/nexus/RegisterGenerator Back2backGammas
+/nexus/RegisterGenerator IonGenerator
 #/nexus/RegisterGenerator SingleParticleGenerator
 
 ### ACTIONS
@@ -190,7 +190,9 @@ def test_create_petalo_output_file_pet_box_all_tiles(config_tmpdir, output_tmpdi
 /Geometry/PetBox/sipm_time_binning 5. picosecond
 /Geometry/PetBox/sipm_pde 0.5
 
-/Generator/Back2back/region CENTER
+/Generator/IonGenerator/region SOURCE
+/Generator/IonGenerator/atomic_number 11
+/Generator/IonGenerator/mass_number 22
 
 /process/optical/processActivation Cerenkov false
 

--- a/tests/pytest/produce_output_test.py
+++ b/tests/pytest/produce_output_test.py
@@ -145,7 +145,7 @@ def test_create_petalo_output_file_ring_tiles(config_tmpdir, output_tmpdir, PETA
 @pytest.mark.order(3)
 def test_create_petalo_output_file_pet_box_all_tiles(config_tmpdir, output_tmpdir, PETALODIR, petalosim_pet_box_params):
 
-     _, base_name, tile_type1, tile_type2, _, _, _, _, _ = petalosim_pet_box_params
+     _, base_name, tile_type1, tile_type2, _, _, _, _, _, min_charge_evt = petalosim_pet_box_params
 
      init_text = f"""
 /PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
@@ -164,7 +164,7 @@ def test_create_petalo_output_file_pet_box_all_tiles(config_tmpdir, output_tmpdi
 
 ### ACTIONS
 /nexus/RegisterRunAction PetaloRunAction
-/nexus/RegisterEventAction PetaloEventAction
+/nexus/RegisterEventAction PetSensorsEventAction
 /nexus/RegisterTrackingAction PetaloTrackingAction
 
 /nexus/RegisterPersistencyManager PetaloPersistencyManager
@@ -193,6 +193,8 @@ def test_create_petalo_output_file_pet_box_all_tiles(config_tmpdir, output_tmpdi
 /Generator/IonGenerator/region SOURCE
 /Generator/IonGenerator/atomic_number 11
 /Generator/IonGenerator/mass_number 22
+
+/Actions/PetSensorsEventAction/min_charge {min_charge_evt}
 
 /process/optical/processActivation Cerenkov false
 

--- a/tests/pytest/sensitive_detectors_test.py
+++ b/tests/pytest/sensitive_detectors_test.py
@@ -29,9 +29,11 @@ def test_sensor_ids(petalosim_params):
 
 def test_sensor_ids_pet_box(petalosim_pet_box_params):
      """
-     Check that sensors are correctly numbered for the PetBox geometry.
+     Check that sensors are correctly numbered for the PetBox geometry,
+     the charge of the event is above a threshold and that the true
+     information is stored if charge is detected by the sensors.
      """
-     filename, _, _, _, nsipms, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name = petalosim_pet_box_params
+     filename, _, _, _, nsipms, sipms_per_tile, init_sns_id1, init_sns_id2, sensor_name, min_charge_evt = petalosim_pet_box_params
 
      sns_response = pd.read_hdf(filename, 'MC/sns_response')
      sipm_ids     = sns_response.sensor_id.unique()
@@ -63,3 +65,11 @@ def test_sensor_ids_pet_box(petalosim_pet_box_params):
          assert len(np.unique(sns_z_pos_right)) == 1
          assert     np.unique(sns_z_pos_right)  < 0
          assert len(sns_z_pos_right) <= sipms_per_tile*4
+
+     # Charge of the whole event above a certain threshold
+     for evt_charge in sns_response.groupby('event_id').charge.sum():
+         assert evt_charge >= min_charge_evt
+
+     # Check that all the stored events have detected charge
+     mcparticles = pd.read_hdf(filename, 'MC/particles')
+     assert mcparticles.event_id.nunique() == sns_response.event_id.nunique()


### PR DESCRIPTION
`PetSensorsEventAction` has been modified by introducing the configuration parameter `min_charge`, which constitutes the minimum charge detected by the sensors to save the event to file.

Additionally, the duplication of pyrex optical material properties has been commented in the `PetBox` class.