### PR TITLE
Add NEST to the code

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -251,12 +251,12 @@ if not env['LIBPATH']:
 
 
     ## NEST configuration --------------------------
-    env.Append( LIBPATH = [os.environ['NEST_DIR']+'/lib'] )
-    env.Append( CPPPATH = [os.environ['NEST_DIR']+'/include'] )
-    env.Append( CPPPATH = [os.environ['NEST_DIR']+'/include/Detectors'] )
-    env.Append( CPPPATH = [os.environ['NEST_DIR']+'/include/NEST'] )
-    env.Append( CPPPATH = [os.environ['NEST_DIR']+'/include/NEST/G4'] )
-    env.Append( CPPPATH = [os.environ['NEST_DIR']+'/include/NEST/gcem_incl'] )
+    env.Append( LIBPATH = [os.environ['NEST_LIB']] )
+    env.Append( CPPPATH = [os.environ['NEST_INC']] )
+    env.Append( CPPPATH = [os.environ['NEST_INC']+'/Detectors'] )
+    env.Append( CPPPATH = [os.environ['NEST_INC']+'/NEST'] )
+    env.Append( CPPPATH = [os.environ['NEST_INC']+'/NEST/G4'] )
+    env.Append( CPPPATH = [os.environ['NEST_INC']+'/NEST/gcem_incl'] )
     env.Append(LIBS = ['NESTCore', 'NESTG4'])
 
     if not conf.CheckCXXHeader('NEST.hh'):

--- a/SConstruct
+++ b/SConstruct
@@ -250,6 +250,22 @@ if not env['LIBPATH']:
         Abort('NEXUS libraries could not be found.')
 
 
+    ## NEST configuration --------------------------
+    env.Append( LIBPATH = [os.environ['NEST_DIR']+'/lib'] )
+    env.Append( CPPPATH = [os.environ['NEST_DIR']+'/include'] )
+    env.Append( CPPPATH = [os.environ['NEST_DIR']+'/include/Detectors'] )
+    env.Append( CPPPATH = [os.environ['NEST_DIR']+'/include/NEST'] )
+    env.Append( CPPPATH = [os.environ['NEST_DIR']+'/include/NEST/G4'] )
+    env.Append( CPPPATH = [os.environ['NEST_DIR']+'/include/NEST/gcem_incl'] )
+    env.Append(LIBS = ['NESTCore', 'NESTG4'])
+
+    if not conf.CheckCXXHeader('NEST.hh'):
+        Abort('NEST headers not found.')
+
+    if not conf.CheckLib(library='NESTG4', language='CXX', autoadd=0):
+        Abort('NEST libraries could not be found.')
+
+
 ## ##################################################################
 
     ## Force nexus to use C++17 standard

--- a/macros/PET_full_body_nest.config.mac
+++ b/macros/PET_full_body_nest.config.mac
@@ -1,0 +1,39 @@
+
+### GEOMETRY
+
+/Geometry/FullRingInfinity/depth 3. cm
+/Geometry/FullRingInfinity/pitch 7. mm
+/Geometry/FullRingInfinity/inner_radius 380. mm
+/Geometry/FullRingInfinity/sipm_rows 278
+/Geometry/FullRingInfinity/instrumented_faces 1
+/Geometry/FullRingInfinity/specific_vertex 0. 0. 0. cm
+
+/Geometry/SiPMpet/efficiency 0.3
+/Geometry/SiPMpet/visibility true
+/Geometry/SiPMpet/time_binning 5. picosecond
+/Geometry/SiPMpet/size 6. mm
+
+
+### GENERATOR
+/Generator/Back2back/region AD_HOC
+#/Generator/Back2back/region CUSTOM
+
+/process/optical/processActivation Scintillation false
+/PhysicsList/Petalo/nest true
+
+
+### VERBOSITIES
+/run/verbose 1
+/event/verbose 0
+/tracking/verbose 0
+
+/process/em/verbose 0
+
+/nexus/random_seed 132312
+
+### OUTPUT FILE
+
+/nexus/persistency/start_id 0
+/nexus/persistency/sns_only false
+/nexus/persistency/tof_time 5. nanosecond
+/nexus/persistency/outputFile full_body_nest

--- a/macros/PET_full_body_nest.init.mac
+++ b/macros/PET_full_body_nest.init.mac
@@ -1,0 +1,23 @@
+### PHYSICS
+/PhysicsList/RegisterPhysics G4EmStandardPhysics_option4
+/PhysicsList/RegisterPhysics G4OpticalPhysics
+/PhysicsList/RegisterPhysics PetaloPhysics
+/PhysicsList/RegisterPhysics G4DecayPhysics
+/PhysicsList/RegisterPhysics G4RadioactiveDecayPhysics
+/PhysicsList/RegisterPhysics G4StepLimiterPhysics
+
+### GEOMETRY
+/nexus/RegisterGeometry FullRingInfinity
+
+### GENERATOR
+/nexus/RegisterGenerator Back2backGammas
+
+### ACTIONS
+/nexus/RegisterRunAction DefaultRunAction
+/nexus/RegisterEventAction PetaloEventAction
+/nexus/RegisterTrackingAction PetaloTrackingAction
+/nexus/RegisterStackingAction PetNESTStackingAction
+
+/nexus/RegisterPersistencyManager PetaloPersistencyManager
+
+/nexus/RegisterMacro macros/PET_full_body_nest.config.mac

--- a/source/actions/PetNESTStackingAction.cc
+++ b/source/actions/PetNESTStackingAction.cc
@@ -1,0 +1,24 @@
+// ----------------------------------------------------------------------------
+// petalosim | PetNESTStackingAction.cc
+//
+// This is the stacking action needed to use NEST.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#include "PetNESTStackingAction.h"
+
+#include "nexus/FactoryBase.h"
+
+
+REGISTER_CLASS(PetNESTStackingAction, G4UserStackingAction)
+
+PetNESTStackingAction::PetNESTStackingAction(): NESTStackingAction()
+{
+}
+
+
+
+PetNESTStackingAction::~PetNESTStackingAction()
+{
+}

--- a/source/actions/PetNESTStackingAction.h
+++ b/source/actions/PetNESTStackingAction.h
@@ -1,0 +1,28 @@
+// ----------------------------------------------------------------------------
+// petalosim | PetNESTStackingAction.h
+//
+// This is the stacking action needed to use NEST.
+//
+// The PETALO Collaboration
+// ----------------------------------------------------------------------------
+
+#ifndef PET_NEST_STACKING_ACTION_H
+#define PET_NEST_STACKING_ACTION_H
+
+#include <G4UserStackingAction.hh>
+
+#include <NESTStackingAction.hh>
+
+// General-purpose user stacking action
+
+class PetNESTStackingAction : public NESTStackingAction
+{
+public:
+  /// Constructor
+  PetNESTStackingAction();
+  /// Destructor
+  ~PetNESTStackingAction();
+
+};
+
+#endif

--- a/source/actions/PetaloTrackingAction.cc
+++ b/source/actions/PetaloTrackingAction.cc
@@ -15,6 +15,8 @@
 #include "nexus/TrajectoryMap.h"
 #include "nexus/FactoryBase.h"
 
+#include <NESTProc.hh>
+
 #include <G4Track.hh>
 #include <G4TrackingManager.hh>
 #include <G4Trajectory.hh>
@@ -42,7 +44,8 @@ PetaloTrackingAction::~PetaloTrackingAction()
 void PetaloTrackingAction::PreUserTrackingAction(const G4Track* track)
 {
   // Do nothing if the track is an optical photon
-  if (track->GetDefinition() == G4OpticalPhoton::Definition()) {
+  if (track->GetDefinition() == G4OpticalPhoton::Definition() ||
+      track->GetDefinition() == NEST::NESTThermalElectron::Definition()) {
       fpTrackingManager->SetStoreTrajectory(false);
       return;
   }

--- a/source/persistency/PetaloPersistencyManager.cc
+++ b/source/persistency/PetaloPersistencyManager.cc
@@ -44,8 +44,8 @@ REGISTER_CLASS(PetaloPersistencyManager, PersistencyManagerBase)
 PetaloPersistencyManager::PetaloPersistencyManager():
   PersistencyManagerBase(), msg_(0), ready_(false), store_evt_(true),
   store_steps_(false), interacting_evt_(false), save_int_e_numb_(false),
-  event_type_("other"), saved_evts_(0), interacting_evts_(0),
-  nevt_(0), start_id_(0), first_evt_(true),
+  efield_(0), event_type_("other"),
+  saved_evts_(0), interacting_evts_(0), nevt_(0), start_id_(0), first_evt_(true),
   thr_charge_(0), tof_time_(50.*nanosecond), sns_only_(false),
   save_tot_charge_(true), h5writer_(0)
 {
@@ -437,9 +437,12 @@ G4bool PetaloPersistencyManager::Store(const G4Run*)
   h5writer_->WriteRunInfo(key, (std::to_string(tof_bin_size_/picosecond)+" ps").c_str());
 
   if (save_int_e_numb_) {
-     key = "interacting_events";
-     h5writer_->WriteRunInfo(key,  std::to_string(interacting_evts_).c_str());
+    key = "interacting_events";
+    h5writer_->WriteRunInfo(key,  std::to_string(interacting_evts_).c_str());
    }
+
+  key = "electric_field";
+  h5writer_->WriteRunInfo(key, (std::to_string(efield_)+" V/cm").c_str());
 
   SaveConfigurationInfo(init_macro_);
   for (unsigned long i=0; i<macros_.size(); i++) {

--- a/source/persistency/PetaloPersistencyManager.h
+++ b/source/persistency/PetaloPersistencyManager.h
@@ -37,6 +37,8 @@ public:
   void StoreSteps(G4bool);
   void SaveNumbOfInteractingEvents(G4bool);
 
+  void SetElectricField(G4double);
+
   ///
   virtual G4bool Store(const G4Event *);
   virtual G4bool Store(const G4Run *);
@@ -69,6 +71,8 @@ private:
   G4bool store_steps_;     ///< Should we store the steps for the current event?
   G4bool interacting_evt_; ///< Has the current event interacted in ACTIVE?
   G4bool save_int_e_numb_; ///< Should we save the number of interacting events in the configuration table?
+
+  G4double efield_; ///< Value of the electric field used in NEST
 
   G4String event_type_; ///< event type: bb0nu, bb2nu, background or not set
 
@@ -108,6 +112,10 @@ inline void PetaloPersistencyManager::InteractingEvent(G4bool ie)
 inline void PetaloPersistencyManager::SaveNumbOfInteractingEvents(G4bool sie)
 {
   save_int_e_numb_ = sie;
+}
+inline void PetaloPersistencyManager::SetElectricField(G4double efield)
+{
+  efield_ = efield;
 }
 inline G4bool PetaloPersistencyManager::Store(const G4VPhysicalVolume *)
 {

--- a/source/physics_lists/PetaloPhysics.cc
+++ b/source/physics_lists/PetaloPhysics.cc
@@ -10,6 +10,9 @@
 #include "WavelengthShifting.h"
 #include "PositronAnnihilation.h"
 
+#include "NESTProc.hh"
+#include "PetaloDetector.hh"
+
 #include <G4Scintillation.hh>
 #include <G4GenericMessenger.hh>
 #include <G4OpticalPhoton.hh>
@@ -26,16 +29,20 @@
 /// with the generic physics list
 G4_DECLARE_PHYSCONSTR_FACTORY(PetaloPhysics);
 
-PetaloPhysics::PetaloPhysics() : G4VPhysicsConstructor("PetaloPhysics"), risetime_(false), noCompt_(false)
+PetaloPhysics::PetaloPhysics() : G4VPhysicsConstructor("PetaloPhysics"),
+                                 risetime_(false), noCompt_(false), nest_(false)
 {
   msg_ = new G4GenericMessenger(this, "/PhysicsList/Petalo/",
                                 "Control commands of the nexus physics list.");
 
   msg_->DeclareProperty("scintRiseTime", risetime_,
-                        "True if LYSO is used");
+                        "Must be true if LYSO is used");
 
   msg_->DeclareProperty("offCompt", noCompt_,
-                        "Switch off Compton Scattering.");
+                        "If true, switches off Compton Scattering.");
+
+  msg_->DeclareProperty("nest", nest_,
+                        "If true, NEST is used for scintillation.");
 }
 
 PetaloPhysics::~PetaloPhysics()
@@ -47,6 +54,7 @@ PetaloPhysics::~PetaloPhysics()
 void PetaloPhysics::ConstructParticle()
 {
   G4OpticalPhoton::Definition();
+  NEST::NESTThermalElectron::Definition();
 }
 
 void PetaloPhysics::ConstructProcess()
@@ -93,4 +101,24 @@ void PetaloPhysics::ConstructProcess()
     pmanager->RemoveProcess(cs);
   }
 
+
+  if (nest_) {
+    PetaloDetector* petalo = new PetaloDetector();
+    NEST::NESTcalc* petaloCalc = new NEST::NESTcalc(petalo);
+    NEST::NESTProc* theNESTScintillationProcess =
+      new NEST::NESTProc("S1", fElectromagnetic, petaloCalc, petalo);
+    theNESTScintillationProcess->SetDetailedSecondaries(true); // this is to use the full scintillation spectrum of LXe.
+    //    theNESTScintillationProcess->SetStackElectrons(false); false if only light is collected
+    
+    auto aParticleIterator = GetParticleIterator();
+    aParticleIterator->reset();
+    while ((*aParticleIterator)()) {
+      G4ParticleDefinition* particle = aParticleIterator->value();
+      if (theNESTScintillationProcess->IsApplicable(*particle)) {
+        pmanager = particle->GetProcessManager();
+        pmanager->AddProcess(theNESTScintillationProcess, ordDefault+1, ordInActive, ordDefault+1);
+      }
+    }
+  }
+  
 }

--- a/source/physics_lists/PetaloPhysics.cc
+++ b/source/physics_lists/PetaloPhysics.cc
@@ -108,7 +108,7 @@ void PetaloPhysics::ConstructProcess()
     NEST::NESTProc* theNESTScintillationProcess =
       new NEST::NESTProc("S1", fElectromagnetic, petaloCalc, petalo);
     theNESTScintillationProcess->SetDetailedSecondaries(true); // this is to use the full scintillation spectrum of LXe.
-    //    theNESTScintillationProcess->SetStackElectrons(false); false if only light is collected
+    theNESTScintillationProcess->SetStackElectrons(true); //false if only light is collected
     
     auto aParticleIterator = GetParticleIterator();
     aParticleIterator->reset();

--- a/source/physics_lists/PetaloPhysics.cc
+++ b/source/physics_lists/PetaloPhysics.cc
@@ -9,6 +9,7 @@
 #include "PetaloPhysics.h"
 #include "WavelengthShifting.h"
 #include "PositronAnnihilation.h"
+#include "PetaloPersistencyManager.h"
 
 #include "NESTProc.hh"
 #include "PetaloDetector.hh"
@@ -104,6 +105,10 @@ void PetaloPhysics::ConstructProcess()
 
   if (nest_) {
     PetaloDetector* petalo = new PetaloDetector();
+    G4double e_field = petalo->FitEF(0, 0, 0);
+    PetaloPersistencyManager* pm =
+      dynamic_cast<PetaloPersistencyManager*>(G4VPersistencyManager::GetPersistencyManager());
+    pm->SetElectricField(e_field);
     NEST::NESTcalc* petaloCalc = new NEST::NESTcalc(petalo);
     NEST::NESTProc* theNESTScintillationProcess =
       new NEST::NESTProc("S1", fElectromagnetic, petaloCalc, petalo);

--- a/source/physics_lists/PetaloPhysics.h
+++ b/source/physics_lists/PetaloPhysics.h
@@ -31,7 +31,9 @@ public:
 private:
   G4bool risetime_; ///< Rise time for LYSO
 
-  G4bool noCompt_; ///< Switch off Compton scattering
+  G4bool noCompt_; ///< Switch on/off Compton scattering
+
+  G4bool nest_; ///< Switch on/off NEST
 
   G4GenericMessenger *msg_;
   WavelengthShifting *wls_;


### PR DESCRIPTION
This PR adds the dependency on NEST, a code to simulate the correct scintillation and ionization charge yield in the presence of an electric field. A macro is added to illustrate how to use `petalosim` with this dependence.